### PR TITLE
Update ex2.hs

### DIFF
--- a/ch07/ex2.hs
+++ b/ch07/ex2.hs
@@ -46,14 +46,11 @@ takeWhile''' p =
     []
 
 -- d. dropWhile
+
 dropWhile' :: (a -> Bool) -> [a] -> [a]
-dropWhile' p =
-  foldl
-    (\xs x ->
-       if p x
-         then []
-         else xs ++ [x])
-    []
+dropWhile' f =foldl (\xs x -> if (f x) && ( length xs == 0) then [] else xs ++ [x])  []
+
+
 
 dropWhile'' :: (a -> Bool) -> [a] -> [a]
 dropWhile'' p [] = []


### PR DESCRIPTION
dropWhile' :: (a -> Bool) -> [a] -> [a]
dropWhile' f =foldl (\xs x -> if (f x) && ( length xs == 0) then [] else xs ++ [x])  []
this new dropwhile I added works better if the item reapears again in the list:
what it does:
ghci> dropWhile' (==1) [1,1,2,3,4,5,1,2,3]
[2,3]
what it should do:
ghci> dropWhile (==1) [1,1,2,3,4,5,1,2,3] 
[2,3,4,5,1,2,3]
the new function I added fixes this problem :)