### PR TITLE
Correct luhn to work for odd-length numbers

### DIFF
--- a/ch07/ex10.hs
+++ b/ch07/ex10.hs
@@ -9,4 +9,4 @@ luhnDouble x =
     else x * 2
 
 luhn :: [Int] -> Bool
-luhn xs = sum (altMap luhnDouble id xs) `mod` 10 == 0
+luhn xs = sum (altMap id luhnDouble $ reverse xs) `mod` 10 == 0


### PR DESCRIPTION
The last digit of a Luhn number is the checksum, so we have to evaluate from right to left. The current implementation only works for even-length numbers. Check with e.g. [7,3,5,9,1,4,4] - it should be True but outputs False.